### PR TITLE
Remove terminationGracePeriodSeconds from CronJob spec 

### DIFF
--- a/tasks/ckad/mock/02/worker/files/solutions/2.MD
+++ b/tasks/ckad/mock/02/worker/files/solutions/2.MD
@@ -31,7 +31,6 @@ spec:
         metadata:
           creationTimestamp: null
         spec:
-          terminationGracePeriodSeconds: 10                    # add it
           containers:
           - image: viktoruj/ping_pong:alpine
             name: cron-job1
@@ -40,6 +39,7 @@ spec:
           restartPolicy: OnFailure
       backoffLimit: 4                                         # add it
       completions: 3                                          # add it
+      activeDeadlineSeconds: 10                               # add it
   schedule: '*/15 * * * *'
   concurrencyPolicy: Forbid                                    # add it
 status: {}

--- a/tasks/ckad/mock/02/worker/files/tests.bats
+++ b/tasks/ckad/mock/02/worker/files/tests.bats
@@ -102,9 +102,9 @@ export KUBECONFIG=/home/ubuntu/.kube/_config
   [ "$result" == "5" ]
 }
 
-@test "2.10 Create a cron job cron-job1. terminationGracePeriodSeconds" {
+@test "2.10 Create a cron job cron-job1. activeDeadlineSeconds" {
   echo '1'>>/var/work/tests/result/all
-  result=$( kubectl  get cronjobs.batch  cron-job1 -n rnd  --context cluster1-admin@cluster1 -o jsonpath='{.spec.jobTemplate.spec.template.spec.terminationGracePeriodSeconds}')
+  result=$( kubectl  get cronjobs.batch  cron-job1 -n rnd  --context cluster1-admin@cluster1 -o jsonpath='{.spec.jobTemplate.spec.activeDeadlineSeconds}')
   if [[ "$result" == "10" ]]; then
    echo '1'>>/var/work/tests/result/ok
   fi


### PR DESCRIPTION
Set activeDeadlineSeconds is set to 10

Upon reviewing the questions, I've found an incorrect answer in question 2 of CKAD moc2. The solution suggests using terminationGracePeriodSeconds: 10, but the correct parameter should be activeDeadlineSeconds. activeDeadlineSeconds sets a hard time limit on the overall Job's lifespan from its creation, which is a common requirement in CKAD preparation tasks. terminationGracePeriodSeconds, on the other hand, specifies the amount of time Kubernetes gives a Pod to shut down gracefully after receiving a termination signal.