### PR TITLE
CKA LAB 102-103 tests improvements

### DIFF
--- a/tasks/cka/labs/102/worker/files/tests.bats
+++ b/tasks/cka/labs/102/worker/files/tests.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 export KUBECONFIG=/home/ubuntu/.kube/config
-CTX="cluster1-admin@cluster1"
+CTX="--context cluster1-admin@cluster1"
 
 @test "0 Init" {
   echo '' > /var/work/tests/result/all
@@ -8,10 +8,12 @@ CTX="cluster1-admin@cluster1"
   echo '' > /var/work/tests/result/requests
 }
 
+
 @test "1. Deployment web (viktoruj/ping_pong, 3 replicas) exists and ready" {
   echo '1' >> /var/work/tests/result/all
-  image=$(kubectl get deploy web --context $CTX -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null)
-  ready=$(kubectl get deploy web --context $CTX -o jsonpath='{.status.readyReplicas}' 2>/dev/null)
+  NS="-n default"
+  image=$(kubectl get deploy web $CTX $NS -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null)
+  ready=$(kubectl get deploy web $CTX $NS -o jsonpath='{.status.readyReplicas}' 2>/dev/null)
   # web стартует с :latest (задание 1), затем обновляется на :alpine (задание 2) —
   # поэтому здесь проверяем только сам деплой и 3 готовые реплики, без привязки к тегу
   if [[ "$image" == viktoruj/ping_pong:* ]] && [[ "$ready" == "3" ]]; then
@@ -22,8 +24,9 @@ CTX="cluster1-admin@cluster1"
 
 @test "2. web rolled to viktoruj/ping_pong:alpine with >=2 revisions" {
   echo '1' >> /var/work/tests/result/all
-  image=$(kubectl get deploy web --context $CTX -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null)
-  revs=$(kubectl rollout history deploy web --context $CTX 2>/dev/null | grep -cE '^[0-9]+')
+  NS="-n default"
+  image=$(kubectl get deploy web $CTX $NS -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null)
+  revs=$(kubectl rollout history deploy web $CTX $NS 2>/dev/null | grep -cE '^[0-9]+')
   if [[ "$image" == "viktoruj/ping_pong:alpine" ]] && [[ "$revs" -ge 2 ]]; then
     echo '1' >> /var/work/tests/result/ok; result=0
   else echo "web image=$image revisions=$revs"; result=1; fi
@@ -32,8 +35,9 @@ CTX="cluster1-admin@cluster1"
 
 @test "3. Deployment roll rolled back to viktoruj/ping_pong:latest (>=3 revisions history)" {
   echo '1' >> /var/work/tests/result/all
-  image=$(kubectl get deploy roll --context $CTX -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null)
-  gen=$(kubectl get deploy roll --context $CTX -o jsonpath='{.metadata.generation}' 2>/dev/null)
+  NS="-n default"
+  image=$(kubectl get deploy roll $CTX $NS -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null)
+  gen=$(kubectl get deploy roll $CTX $NS -o jsonpath='{.metadata.generation}' 2>/dev/null)
   if [[ "$image" == "viktoruj/ping_pong:latest" ]] && [[ "$gen" -ge 3 ]]; then
     echo '1' >> /var/work/tests/result/ok; result=0
   else echo "roll image=$image generation=$gen"; result=1; fi
@@ -42,10 +46,11 @@ CTX="cluster1-admin@cluster1"
 
 @test "4. Canary in ns canary: app-v1=7, app-v2=3, service app selects app=app" {
   echo '1' >> /var/work/tests/result/all
-  v1=$(kubectl get deploy app-v1 -n canary --context $CTX -o jsonpath='{.spec.replicas}' 2>/dev/null)
-  v2=$(kubectl get deploy app-v2 -n canary --context $CTX -o jsonpath='{.spec.replicas}' 2>/dev/null)
-  sel=$(kubectl get svc app -n canary --context $CTX -o jsonpath='{.spec.selector.app}' 2>/dev/null)
-  eps=$(kubectl get endpoints app -n canary --context $CTX -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null | wc -w)
+  NS="-n canary"
+  v1=$(kubectl get deploy app-v1 $CTX $NS -o jsonpath='{.spec.replicas}' 2>/dev/null)
+  v2=$(kubectl get deploy app-v2 $CTX $NS -o jsonpath='{.spec.replicas}' 2>/dev/null)
+  sel=$(kubectl get svc app $CTX $NS -o jsonpath='{.spec.selector.app}' 2>/dev/null)
+  eps=$(kubectl get endpoints app $CTX $NS -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null | wc -w)
   if [[ "$v1" == "7" ]] && [[ "$v2" == "3" ]] && [[ "$sel" == "app" ]] && [[ "$eps" -ge 1 ]]; then
     echo '1' >> /var/work/tests/result/ok; result=0
   else echo "v1=$v1 v2=$v2 selector=$sel endpoints=$eps"; result=1; fi
@@ -54,9 +59,10 @@ CTX="cluster1-admin@cluster1"
 
 @test "5. Deployment web strategy: RollingUpdate maxSurge=2, maxUnavailable=0" {
   echo '1' >> /var/work/tests/result/all
-  st=$(kubectl get deploy web --context $CTX -o jsonpath='{.spec.strategy.type}' 2>/dev/null)
-  ms=$(kubectl get deploy web --context $CTX -o jsonpath='{.spec.strategy.rollingUpdate.maxSurge}' 2>/dev/null)
-  mu=$(kubectl get deploy web --context $CTX -o jsonpath='{.spec.strategy.rollingUpdate.maxUnavailable}' 2>/dev/null)
+  NS="-n default"
+  st=$(kubectl get deploy web $CTX $NS -o jsonpath='{.spec.strategy.type}' 2>/dev/null)
+  ms=$(kubectl get deploy web $CTX $NS -o jsonpath='{.spec.strategy.rollingUpdate.maxSurge}' 2>/dev/null)
+  mu=$(kubectl get deploy web $CTX $NS -o jsonpath='{.spec.strategy.rollingUpdate.maxUnavailable}' 2>/dev/null)
   if [[ "$st" == "RollingUpdate" ]] && [[ "$ms" == "2" ]] && [[ "$mu" == "0" ]]; then
     echo '1' >> /var/work/tests/result/ok; result=0
   else echo "web strategy=$st maxSurge=$ms maxUnavailable=$mu"; result=1; fi
@@ -65,10 +71,11 @@ CTX="cluster1-admin@cluster1"
 
 @test "6. Blue/Green in ns bg: service bg-svc switched to version=green" {
   echo '1' >> /var/work/tests/result/all
-  sel=$(kubectl get svc bg-svc -n bg --context $CTX -o jsonpath='{.spec.selector.version}' 2>/dev/null)
-  blue=$(kubectl get deploy bg-blue -n bg --context $CTX -o jsonpath='{.metadata.name}' 2>/dev/null)
-  green=$(kubectl get deploy bg-green -n bg --context $CTX -o jsonpath='{.metadata.name}' 2>/dev/null)
-  eps=$(kubectl get endpoints bg-svc -n bg --context $CTX -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null | wc -w)
+  NS="-n bg"
+  sel=$(kubectl get svc bg-svc $CTX $NS -o jsonpath='{.spec.selector.version}' 2>/dev/null)
+  blue=$(kubectl get deploy bg-blue $CTX $NS -o jsonpath='{.metadata.name}' 2>/dev/null)
+  green=$(kubectl get deploy bg-green $CTX $NS -o jsonpath='{.metadata.name}' 2>/dev/null)
+  eps=$(kubectl get endpoints bg-svc $CTX $NS -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null | wc -w)
   if [[ "$sel" == "green" ]] && [[ "$blue" == "bg-blue" ]] && [[ "$green" == "bg-green" ]] && [[ "$eps" -ge 1 ]]; then
     echo '1' >> /var/work/tests/result/ok; result=0
   else echo "bg-svc selector.version=$sel blue=$blue green=$green endpoints=$eps"; result=1; fi

--- a/tasks/cka/labs/103/k8s-1/scripts/master.sh
+++ b/tasks/cka/labs/103/k8s-1/scripts/master.sh
@@ -5,6 +5,3 @@ export KUBECONFIG=/root/.kube/config
 kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
 kubectl -n kube-system patch deployment metrics-server --type=json \
   -p='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--kubelet-insecure-tls"}]'
-
-# keep control-plane taint so DaemonSet toleration is meaningful, but allow scheduling
-kubectl taint nodes $(hostname) node-role.kubernetes.io/control-plane:NoSchedule- || true

--- a/tasks/cka/labs/103/worker/files/tests.bats
+++ b/tasks/cka/labs/103/worker/files/tests.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 export KUBECONFIG=/home/ubuntu/.kube/config
-CTX="cluster1-admin@cluster1"
+CTX="--context cluster1-admin@cluster1"
 
 @test "0 Init" {
   echo '' > /var/work/tests/result/all
@@ -10,10 +10,11 @@ CTX="cluster1-admin@cluster1"
 
 @test "1. Job hi-job (busybox, completions 3, backoffLimit 6, restartPolicy Never)" {
   echo '1' >> /var/work/tests/result/all
-  image=$(kubectl get job hi-job --context $CTX -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null)
-  comp=$(kubectl get job hi-job --context $CTX -o jsonpath='{.spec.completions}' 2>/dev/null)
-  bo=$(kubectl get job hi-job --context $CTX -o jsonpath='{.spec.backoffLimit}' 2>/dev/null)
-  rp=$(kubectl get job hi-job --context $CTX -o jsonpath='{.spec.template.spec.restartPolicy}' 2>/dev/null)
+  NS="-n default"
+  image=$(kubectl get job hi-job $CTX $NS -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null)
+  comp=$(kubectl get job hi-job $CTX $NS -o jsonpath='{.spec.completions}' 2>/dev/null)
+  bo=$(kubectl get job hi-job $CTX $NS -o jsonpath='{.spec.backoffLimit}' 2>/dev/null)
+  rp=$(kubectl get job hi-job $CTX $NS -o jsonpath='{.spec.template.spec.restartPolicy}' 2>/dev/null)
   if [[ "$image" == busybox* ]] && [[ "$comp" == "3" ]] && [[ "$bo" == "6" ]] && [[ "$rp" == "Never" ]]; then
     echo '1' >> /var/work/tests/result/ok; result=0
   else echo "hi-job image=$image completions=$comp backoff=$bo restartPolicy=$rp"; result=1; fi
@@ -22,21 +23,26 @@ CTX="cluster1-admin@cluster1"
 
 @test "2. CronJob cron-job1 in rnd (schedule */15, Forbid, hist 5/7)" {
   echo '1' >> /var/work/tests/result/all
-  sch=$(kubectl get cronjob cron-job1 -n rnd --context $CTX -o jsonpath='{.spec.schedule}' 2>/dev/null)
-  cp=$(kubectl get cronjob cron-job1 -n rnd --context $CTX -o jsonpath='{.spec.concurrencyPolicy}' 2>/dev/null)
-  sh=$(kubectl get cronjob cron-job1 -n rnd --context $CTX -o jsonpath='{.spec.successfulJobsHistoryLimit}' 2>/dev/null)
-  fh=$(kubectl get cronjob cron-job1 -n rnd --context $CTX -o jsonpath='{.spec.failedJobsHistoryLimit}' 2>/dev/null)
-  if [[ "$sch" == "*/15 * * * *" ]] && [[ "$cp" == "Forbid" ]] && [[ "$sh" == "5" ]] && [[ "$fh" == "7" ]]; then
+  NS="-n rnd"
+  sch=$(kubectl get cronjob cron-job1 $CTX $NS -o jsonpath='{.spec.schedule}' 2>/dev/null)
+  cp=$(kubectl get cronjob cron-job1 $CTX $NS -o jsonpath='{.spec.concurrencyPolicy}' 2>/dev/null)
+  sh=$(kubectl get cronjob cron-job1 $CTX $NS -o jsonpath='{.spec.successfulJobsHistoryLimit}' 2>/dev/null)
+  fh=$(kubectl get cronjob cron-job1 $CTX $NS -o jsonpath='{.spec.failedJobsHistoryLimit}' 2>/dev/null)
+  cpl=$(kubectl get cronjob cron-job1 $CTX $NS -o jsonpath='{.spec.jobTemplate.spec.completions}' 2>/dev/null)
+  bkl=$(kubectl get cronjob cron-job1 $CTX $NS -o jsonpath='{.spec.jobTemplate.spec.backoffLimit}' 2>/dev/null)
+  ads=$(kubectl get cronjob cron-job1 $CTX $NS -o jsonpath='{.spec.jobTemplate.spec.activeDeadlineSeconds}' 2>/dev/null)
+  if [[ "$sch" == "*/15 * * * *" ]] && [[ "$cp" == "Forbid" ]] && [[ "$sh" == "5" ]] && [[ "$fh" == "7" ]] && [[ "$cpl" == "3" ]] && [[ "$bkl" == "4" ]] && [[ "$ads" == "10" ]]; then
     echo '1' >> /var/work/tests/result/ok; result=0
-  else echo "cron schedule=$sch concurrency=$cp succHist=$sh failHist=$fh"; result=1; fi
+  else echo "cron schedule=$sch concurrency=$cp succHist=$sh failHist=$fh completions=$cpl backoffLim=$bkl activeDlSec=$ads "; result=1; fi
   [ "$result" == "0" ]
 }
 
 @test "3. DaemonSet important-app in app-system runs on ALL nodes" {
   echo '1' >> /var/work/tests/result/all
-  nodes=$(kubectl get nodes --context $CTX --no-headers 2>/dev/null | wc -l)
-  desired=$(kubectl get ds important-app -n app-system --context $CTX -o jsonpath='{.status.desiredNumberScheduled}' 2>/dev/null)
-  ready=$(kubectl get ds important-app -n app-system --context $CTX -o jsonpath='{.status.numberReady}' 2>/dev/null)
+  NS="-n app-system"
+  nodes=$(kubectl get nodes $CTX --no-headers 2>/dev/null | wc -l)
+  desired=$(kubectl get ds important-app $CTX $NS -o jsonpath='{.status.desiredNumberScheduled}' 2>/dev/null)
+  ready=$(kubectl get ds important-app $CTX $NS -o jsonpath='{.status.numberReady}' 2>/dev/null)
   if [[ "$desired" == "$nodes" ]] && [[ "$ready" == "$nodes" ]] && [[ "$nodes" -ge 2 ]]; then
     echo '1' >> /var/work/tests/result/ok; result=0
   else echo "nodes=$nodes desired=$desired ready=$ready"; result=1; fi


### PR DESCRIPTION
1. CKA LAB 102: fix switching context from NS default, tests for NS=default reported erroneously
Added explicit NS param for all tests assuming NS=defaut

2. CKA LAB 103: improve tests

- Test 1: added explicit NS param for all tests assuming NS=defaut
- Test 2: added tests for missed `completions`, `backoffLimit` & `activeDeadlineSeconds`

3. CKA LAB 103: undo control-plane "NoSchedule" taint removal
task states : "...By default a DaemonSet does not place a Pod on the control-plane (there is a taint there)..." but actually there is no taint due to this bug.